### PR TITLE
Show nostr profile on home

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,31 @@
-export default function HomePage() {
+import Image from 'next/image';
+import settings from '../settings.json';
+import { fetchProfile, fetchNotes } from '../lib/nostr';
+import VerticalCarousel from '../components/VerticalCarousel';
+
+export default async function HomePage() {
+  const profile = await fetchProfile(settings.npub);
+  const notes = await fetchNotes(settings.npub, 20);
+
   return (
-    <div className="space-y-2">
-      <h1 className="text-2xl font-bold">Welcome to my Nostr Blog</h1>
+    <div className="grid gap-6 md:grid-cols-2 md:items-start">
+      <div className="flex flex-col items-center space-y-4">
+        {profile.picture && (
+          <Image
+            src={profile.picture}
+            alt="Profile picture"
+            width={200}
+            height={200}
+            className="rounded-full object-cover"
+          />
+        )}
+        <p className="text-lg text-center whitespace-pre-line">
+          {profile.about || settings.bio}
+        </p>
+      </div>
+      <div className="h-80">
+        <VerticalCarousel notes={notes} />
+      </div>
     </div>
   );
 }

--- a/components/VerticalCarousel.tsx
+++ b/components/VerticalCarousel.tsx
@@ -1,0 +1,45 @@
+'use client'
+
+import { useState } from 'react';
+
+export interface CarouselNote {
+  id: string;
+  content: string;
+}
+
+interface VerticalCarouselProps {
+  notes: CarouselNote[];
+}
+
+export default function VerticalCarousel({ notes }: VerticalCarouselProps) {
+  const [start, setStart] = useState(0);
+  const visible = notes.slice(start, start + 3);
+
+  return (
+    <div className="flex flex-col h-full">
+      <div className="flex-1 space-y-4">
+        {visible.map((n) => (
+          <div key={n.id} className="rounded border p-4 bg-white dark:bg-gray-900">
+            {n.content}
+          </div>
+        ))}
+      </div>
+      <div className="mt-2 flex justify-between">
+        <button
+          className="rounded border px-2 py-1 text-sm disabled:opacity-50"
+          disabled={start === 0}
+          onClick={() => setStart(Math.max(start - 1, 0))}
+        >
+          Up
+        </button>
+        <button
+          className="rounded border px-2 py-1 text-sm disabled:opacity-50"
+          disabled={start + 3 >= notes.length}
+          onClick={() => setStart(Math.min(start + 1, notes.length - 3))}
+        >
+          Down
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/lib/nostr.ts
+++ b/lib/nostr.ts
@@ -84,6 +84,17 @@ export async function fetchPosts(pubkey: string): Promise<NostrPost[]> {
   }));
 }
 
+export async function fetchNotes(pubkey: string, limit = 20): Promise<NostrPost[]> {
+  const hex = npubToHex(pubkey);
+  const events = await fetchEvents({ authors: [hex], kinds: [1], limit });
+  return events.map((e) => ({
+    id: e.id,
+    content: e.content,
+    created_at: e.created_at,
+    tags: e.tags?.flat() ?? [],
+  }));
+}
+
 export async function fetchProfile(pubkey: string): Promise<Record<string, any>> {
   const hex = npubToHex(pubkey);
   const [event] = await fetchEvents({ authors: [hex], kinds: [0], limit: 1 });


### PR DESCRIPTION
## Summary
- fetch profile and notes from Nostr
- add `VerticalCarousel` component for scrolling through notes
- display profile photo and description with note carousel on the home page

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688a7c9b786c83269d22d1083eac237f