### PR TITLE
Modernize home page with carousel and theme toggle

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,7 @@
 import Image from 'next/image';
 import settings from '../settings.json';
 import { fetchProfile, fetchNotes } from '../lib/nostr';
-import VerticalCarousel from '../components/VerticalCarousel';
+import LatestPostsCarousel from '../components/LatestPostsCarousel';
 
 export default async function HomePage() {
   const profile = await fetchProfile(settings.npub);
@@ -23,8 +23,8 @@ export default async function HomePage() {
           {profile.about || settings.bio}
         </p>
       </div>
-      <div className="h-80">
-        <VerticalCarousel notes={notes} />
+      <div>
+        <LatestPostsCarousel notes={notes} />
       </div>
     </div>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,22 +8,22 @@ export default async function HomePage() {
   const notes = await fetchNotes(settings.npub, 20);
 
   return (
-    <div className="grid gap-6 md:grid-cols-2 md:items-start">
-      <div className="flex flex-col items-center space-y-4">
+    <div className="flex flex-col gap-6 md:flex-row">
+      <div className="w-full md:w-1/3 space-y-4 text-center flex flex-col items-center">
         {profile.picture && (
           <Image
             src={profile.picture}
             alt="Profile picture"
-            width={200}
-            height={200}
+            width={128}
+            height={128}
             className="rounded-full object-cover"
           />
         )}
-        <p className="text-lg text-center whitespace-pre-line">
+        <p className="whitespace-pre-wrap text-sm md:text-base">
           {profile.about || settings.bio}
         </p>
       </div>
-      <div>
+      <div className="w-full md:w-2/3">
         <LatestPostsCarousel notes={notes} />
       </div>
     </div>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,13 +1,18 @@
 import Link from 'next/link';
+import { fetchProfile } from '../lib/nostr';
+import settings from '../settings.json';
+import ThemeToggle from './ThemeToggle';
 
-export default function Header() {
+export default async function Header() {
+  const profile = await fetchProfile(settings.npub);
+  const siteName = profile?.name || 'Nostr Blog';
   return (
     <header className="border-b bg-white dark:bg-gray-900">
       <div className="container mx-auto flex h-14 items-center justify-between px-4">
         <Link href="/" className="text-lg font-semibold">
-          Nostr Blog
+          {siteName}
         </Link>
-        <nav className="flex gap-4 text-sm font-medium">
+        <nav className="flex items-center gap-4 text-sm font-medium">
           <Link href="/" className="hover:underline">
             Home
           </Link>
@@ -23,6 +28,7 @@ export default function Header() {
           <Link href="/contact" className="hover:underline">
             Contact
           </Link>
+          <ThemeToggle />
         </nav>
       </div>
     </header>

--- a/components/LatestPostsCarousel.tsx
+++ b/components/LatestPostsCarousel.tsx
@@ -1,0 +1,54 @@
+"use client";
+import { useRef } from "react";
+import type { CarouselNote } from "./VerticalCarousel";
+
+interface LatestPostsCarouselProps {
+  notes: CarouselNote[];
+}
+
+export default function LatestPostsCarousel({ notes }: LatestPostsCarouselProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const scroll = (dir: number) => {
+    const el = containerRef.current;
+    if (el) {
+      const width = el.clientWidth;
+      el.scrollBy({ left: width * dir, behavior: "smooth" });
+    }
+  };
+
+  return (
+    <div>
+      <div className="mb-2 flex items-center justify-between">
+        <h2 className="text-xl font-semibold">Latest Posts</h2>
+        <div className="space-x-2">
+          <button
+            onClick={() => scroll(-1)}
+            className="rounded border px-2 py-1 text-sm"
+          >
+            Prev
+          </button>
+          <button
+            onClick={() => scroll(1)}
+            className="rounded border px-2 py-1 text-sm"
+          >
+            Next
+          </button>
+        </div>
+      </div>
+      <div
+        ref={containerRef}
+        className="flex snap-x snap-mandatory space-x-4 overflow-x-auto pb-2"
+      >
+        {notes.map((n) => (
+          <div
+            key={n.id}
+            className="w-64 flex-shrink-0 snap-start rounded border bg-white p-4 dark:bg-gray-900"
+          >
+            {n.content}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/components/LatestPostsCarousel.tsx
+++ b/components/LatestPostsCarousel.tsx
@@ -1,5 +1,4 @@
 "use client";
-import { useRef } from "react";
 import type { CarouselNote } from "./VerticalCarousel";
 
 interface LatestPostsCarouselProps {
@@ -7,45 +6,16 @@ interface LatestPostsCarouselProps {
 }
 
 export default function LatestPostsCarousel({ notes }: LatestPostsCarouselProps) {
-  const containerRef = useRef<HTMLDivElement>(null);
-
-  const scroll = (dir: number) => {
-    const el = containerRef.current;
-    if (el) {
-      const width = el.clientWidth;
-      el.scrollBy({ left: width * dir, behavior: "smooth" });
-    }
-  };
-
   return (
     <div>
-      <div className="mb-2 flex items-center justify-between">
-        <h2 className="text-xl font-semibold">Latest Posts</h2>
-        <div className="space-x-2">
-          <button
-            onClick={() => scroll(-1)}
-            className="rounded border px-2 py-1 text-sm"
-          >
-            Prev
-          </button>
-          <button
-            onClick={() => scroll(1)}
-            className="rounded border px-2 py-1 text-sm"
-          >
-            Next
-          </button>
-        </div>
-      </div>
-      <div
-        ref={containerRef}
-        className="flex snap-x snap-mandatory space-x-4 overflow-x-auto pb-2"
-      >
+      <h2 className="mb-4 text-xl font-semibold">Latest Posts</h2>
+      <div className="grid max-h-[80vh] grid-cols-1 gap-4 overflow-y-auto sm:grid-cols-2">
         {notes.map((n) => (
           <div
             key={n.id}
-            className="w-64 flex-shrink-0 snap-start rounded border bg-white p-4 dark:bg-gray-900"
+            className="rounded border bg-white p-4 dark:bg-gray-900"
           >
-            {n.content}
+            <p className="whitespace-pre-wrap break-words">{n.content}</p>
           </div>
         ))}
       </div>

--- a/components/ThemeToggle.tsx
+++ b/components/ThemeToggle.tsx
@@ -1,0 +1,38 @@
+"use client";
+import { useEffect, useState } from "react";
+
+export default function ThemeToggle() {
+  const [theme, setTheme] = useState("light");
+
+  useEffect(() => {
+    const saved =
+      typeof window !== "undefined" &&
+      (localStorage.getItem("theme") ||
+        (window.matchMedia("(prefers-color-scheme: dark)").matches
+          ? "dark"
+          : "light"));
+    if (saved) {
+      setTheme(saved);
+      document.documentElement.classList.toggle("dark", saved === "dark");
+    }
+  }, []);
+
+  const toggle = () => {
+    const next = theme === "dark" ? "light" : "dark";
+    setTheme(next);
+    document.documentElement.classList.toggle("dark", next === "dark");
+    if (typeof window !== "undefined") {
+      localStorage.setItem("theme", next);
+    }
+  };
+
+  return (
+    <button
+      onClick={toggle}
+      aria-label="Toggle theme"
+      className="rounded border px-2 py-1 text-sm"
+    >
+      {theme === "dark" ? "Light" : "Dark"}
+    </button>
+  );
+}

--- a/components/ThemeToggle.tsx
+++ b/components/ThemeToggle.tsx
@@ -30,9 +30,9 @@ export default function ThemeToggle() {
     <button
       onClick={toggle}
       aria-label="Toggle theme"
-      className="rounded border px-2 py-1 text-sm"
+      className="rounded p-2 hover:bg-gray-200 dark:hover:bg-gray-800"
     >
-      {theme === "dark" ? "Light" : "Dark"}
+      <span aria-hidden>{theme === "dark" ? "🌞" : "🌙"}</span>
     </button>
   );
 }

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -2,6 +2,12 @@
 const nextConfig = {
   reactStrictMode: true,
   experimental: {},
+  images: {
+    remotePatterns: [
+      { protocol: 'https', hostname: '**' },
+      { protocol: 'http', hostname: '**' }
+    ]
+  },
   typescript: {
     ignoreBuildErrors: true
   }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -5,6 +5,7 @@ const config: Config = {
     './app/**/*.{ts,tsx}',
     './components/**/*.{ts,tsx}',
   ],
+  darkMode: 'class',
   theme: {
     extend: {},
   },


### PR DESCRIPTION
## Summary
- allow remote images for profile picture
- enable class-based dark mode
- show NPUB profile name in header and add theme toggle
- replace vertical notes with Latest Posts carousel
- add new components for theme toggling and carousel

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688a8065b6e083268eb6427aa0d28543